### PR TITLE
fix: validate typesense environment variables

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -22,3 +22,12 @@ ENV_VALIDATION="enabled"
 # NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=
 NEXT_PUBLIC_MATOMO_BASE_URL="https://matomo.acdh.oeaw.ac.at"
 # NEXT_PUBLIC_MATOMO_ID=
+
+# -------------------------------------------------------------------------------------------------
+# typesense
+# -------------------------------------------------------------------------------------------------
+NEXT_PUBLIC_TYPESENSE_API_KEY=
+NEXT_PUBLIC_TYPESENSE_HOST="typesense.acdh-dev.oeaw.ac.at"
+NEXT_PUBLIC_TYPESENSE_PORT="443"
+NEXT_PUBLIC_TYPESENSE_PROTOCOL="https"
+

--- a/app/search/instantsearch.tsx
+++ b/app/search/instantsearch.tsx
@@ -8,21 +8,18 @@ import { InstantSearchNext } from "react-instantsearch-nextjs";
 import TypesenseInstantSearchAdapter, { type SearchClient } from "typesense-instantsearch-adapter";
 
 import { ClickablePublicationThumbnail } from "@/components/publication-cover";
+import { env } from "@/config/env.config";
 import { collectionName } from "@/lib/data";
 import type { Publication } from "@/lib/model";
 
 const typesenseInstantsearchAdapter = new TypesenseInstantSearchAdapter({
 	server: {
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		apiKey: process.env.NEXT_PUBLIC_TYPESENSE_API_KEY!,
+		apiKey: env.NEXT_PUBLIC_TYPESENSE_API_KEY,
 		nodes: [
 			{
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				host: process.env.NEXT_PUBLIC_TYPESENSE_HOST!,
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				port: Number(process.env.NEXT_PUBLIC_TYPESENSE_PORT!),
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				protocol: process.env.NEXT_PUBLIC_TYPESENSE_PROTOCOL!,
+				host: env.NEXT_PUBLIC_TYPESENSE_HOST,
+				port: env.NEXT_PUBLIC_TYPESENSE_PORT,
+				protocol: env.NEXT_PUBLIC_TYPESENSE_PROTOCOL,
 			},
 		],
 	},

--- a/components/instantsearch.tsx
+++ b/components/instantsearch.tsx
@@ -7,6 +7,7 @@ import { Configure, SearchBox, useInfiniteHits } from "react-instantsearch";
 import { InstantSearchNext } from "react-instantsearch-nextjs";
 import TypesenseInstantSearchAdapter, { type SearchClient } from "typesense-instantsearch-adapter";
 
+import { env } from "@/config/env.config";
 import { collectionName } from "@/lib/data";
 import type { Publication } from "@/lib/model";
 
@@ -24,16 +25,12 @@ interface InstantSearchProps {
 
 const typesenseInstantsearchAdapter = new TypesenseInstantSearchAdapter({
 	server: {
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		apiKey: process.env.NEXT_PUBLIC_TYPESENSE_API_KEY!,
+		apiKey: env.NEXT_PUBLIC_TYPESENSE_API_KEY,
 		nodes: [
 			{
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				host: process.env.NEXT_PUBLIC_TYPESENSE_HOST!,
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				port: Number(process.env.NEXT_PUBLIC_TYPESENSE_PORT!),
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				protocol: process.env.NEXT_PUBLIC_TYPESENSE_PROTOCOL!,
+				host: env.NEXT_PUBLIC_TYPESENSE_HOST,
+				port: env.NEXT_PUBLIC_TYPESENSE_PORT,
+				protocol: env.NEXT_PUBLIC_TYPESENSE_PROTOCOL,
 			},
 		],
 	},

--- a/config/env.config.js
+++ b/config/env.config.js
@@ -34,11 +34,25 @@ export const env = createEnv({
 				v.integer(),
 				v.minValue(1),
 			),
+			NEXT_PUBLIC_TYPESENSE_API_KEY: v.pipe(v.string(), v.nonEmpty()),
+			NEXT_PUBLIC_TYPESENSE_HOST: v.pipe(v.string(), v.nonEmpty()),
+			NEXT_PUBLIC_TYPESENSE_PORT: v.pipe(
+				v.string(),
+				v.transform(Number),
+				v.number(),
+				v.integer(),
+				v.minValue(1),
+			),
+			NEXT_PUBLIC_TYPESENSE_PROTOCOL: v.pipe(v.string(), v.nonEmpty()),
 		});
 
 		return v.parse(Schema, input);
 	},
 	environment: {
+		NEXT_PUBLIC_TYPESENSE_API_KEY: process.env.NEXT_PUBLIC_TYPESENSE_API_KEY,
+		NEXT_PUBLIC_TYPESENSE_HOST: process.env.NEXT_PUBLIC_TYPESENSE_HOST,
+		NEXT_PUBLIC_TYPESENSE_PORT: process.env.NEXT_PUBLIC_TYPESENSE_PORT,
+		NEXT_PUBLIC_TYPESENSE_PROTOCOL: process.env.NEXT_PUBLIC_TYPESENSE_PROTOCOL,
 		BUILD_MODE: process.env.BUILD_MODE,
 		BUNDLE_ANALYZER: process.env.BUNDLE_ANALYZER,
 		NEXT_PUBLIC_APP_BASE_URL: process.env.NEXT_PUBLIC_APP_BASE_URL,

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,21 +1,18 @@
 import { Client } from "typesense";
 import type { SearchResponse } from "typesense/lib/Typesense/Documents";
 
+import { env } from "@/config/env.config";
 import type { Publication } from "@/lib/model";
 
 export const client = new Client({
 	nodes: [
 		{
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			host: process.env.NEXT_PUBLIC_TYPESENSE_HOST!,
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			port: Number(process.env.NEXT_PUBLIC_TYPESENSE_PORT!),
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			protocol: process.env.NEXT_PUBLIC_TYPESENSE_PROTOCOL!,
+			host: env.NEXT_PUBLIC_TYPESENSE_HOST,
+			port: env.NEXT_PUBLIC_TYPESENSE_PORT,
+			protocol: env.NEXT_PUBLIC_TYPESENSE_PROTOCOL,
 		},
 	],
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	apiKey: process.env.NEXT_PUBLIC_TYPESENSE_API_KEY!,
+	apiKey: env.NEXT_PUBLIC_TYPESENSE_API_KEY,
 	connectionTimeoutSeconds: 2,
 });
 


### PR DESCRIPTION
- validate all environment variables on app start
- document required typesense env vars in `.env.local.example`